### PR TITLE
Add an immutable method

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -10,3 +10,11 @@ defaults(obj, {a: 'bbb', d: 'c'});
 console.log(obj);
 //=> {a: 'c', d: 'c'}
 ```
+
+Or immutable defaulting:
+```js
+var defaults = require('{%= name %}/immutable');
+var obj = {a: 'c'};
+var defaulted = defaults(obj, {a: 'bbb', d: 'c'});
+console.log(obj !== defaulted);
+//=> true

--- a/immutable.js
+++ b/immutable.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var slice = require('array-slice');
+
+var defaults = require('./mutable');
+
+/**
+ * Extends an empty object with properties of one or
+ * more additional `objects`
+ *
+ * @name .defaults.immutable
+ * @param  {Object} `objects`
+ * @return {Object}
+ * @api public
+ */
+
+module.exports = function immutableDefaults() {
+  var args = slice(arguments);
+  return defaults.apply(null, [{}].concat(args));
+};

--- a/index.js
+++ b/index.js
@@ -7,45 +7,5 @@
 
 'use strict';
 
-var each = require('array-each');
-var slice = require('array-slice');
-var forOwn = require('for-own');
-var isObject = require('isobject');
-
-/**
- * Extends the `target` object with properties of one or
- * more additional `objects`
- *
- * @name .defaults
- * @param  {Object} `target` The target object. Pass an empty object to shallow clone.
- * @param  {Object} `objects`
- * @return {Object}
- * @api public
- */
-
-function defaults(target, objects) {
-  if (target == null) {
-    return {};
-  }
-
-  each(slice(arguments, 1), function(obj) {
-    if (isObject(obj)) {
-      forOwn(obj, function(val, key) {
-        if (target[key] == null) {
-          target[key] = val;
-        }
-      });
-    }
-  });
-
-  return target;
-}
-
-function immutable() {
-  var args = slice(arguments);
-  return defaults.apply(null, [{}].concat(args));
-}
-
-defaults.immutable = immutable;
-
-module.exports = defaults;
+module.exports = require('./mutable');
+module.exports.immutable = require('./immutable');

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var isObject = require('isobject');
  * @api public
  */
 
-module.exports = function defaults(target, objects) {
+function defaults(target, objects) {
   if (target == null) {
     return {};
   }
@@ -39,4 +39,13 @@ module.exports = function defaults(target, objects) {
   });
 
   return target;
-};
+}
+
+function immutable() {
+  var args = slice(arguments);
+  return defaults.apply(null, [{}].concat(args));
+}
+
+defaults.immutable = immutable;
+
+module.exports = defaults;

--- a/mutable.js
+++ b/mutable.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var each = require('array-each');
+var slice = require('array-slice');
+var forOwn = require('for-own');
+var isObject = require('isobject');
+
+/**
+ * Extends the `target` object with properties of one or
+ * more additional `objects`
+ *
+ * @name .defaults
+ * @param  {Object} `target` The target object. Pass an empty object to shallow clone.
+ * @param  {Object} `objects`
+ * @return {Object}
+ * @api public
+ */
+
+module.exports = function defaults(target, objects) {
+  if (target == null) {
+    return {};
+  }
+
+  each(slice(arguments, 1), function(obj) {
+    if (isObject(obj)) {
+      forOwn(obj, function(val, key) {
+        if (target[key] == null) {
+          target[key] = val;
+        }
+      });
+    }
+  });
+
+  return target;
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "immutable.js",
+    "mutable.js"
   ],
   "main": "index.js",
   "engines": {

--- a/test.js
+++ b/test.js
@@ -18,7 +18,11 @@ describe('defaults', function () {
     ctx.bar = {ccc: 'eee', fff: 'ggg'};
   });
 
-  it('should return an empty string when undefined.', function() {
+  it('should mutate the first argument.', function() {
+    assert(defaults(ctx.foo, ctx.bar) === ctx.foo);
+  });
+
+  it('should return an empty object when undefined.', function() {
     assert.deepEqual(defaults(), {});
   });
 
@@ -57,5 +61,20 @@ describe('defaults', function () {
 
   it('should return an empty object when the first arg is null.', function () {
     assert.deepEqual(defaults(null), {});
+  });
+});
+
+describe('defaults.immutable', function () {
+  var ctx = {};
+  beforeEach(function () {
+    ctx.foo = {aaa: 'bbb', ccc: 'ddd'};
+    ctx.bar = {ccc: 'eee', fff: 'ggg'};
+  });
+
+  it('should not mutate the first argument.', function() {
+    var result = defaults.immutable(ctx.foo, ctx.bar);
+    assert(result !== ctx.foo);
+    assert.deepEqual(ctx.foo, {aaa: 'bbb', ccc: 'ddd'});
+    assert.deepEqual(result, {aaa:'bbb',ccc:'ddd',fff:'ggg'});
   });
 });


### PR DESCRIPTION
@jonschlinkert this library actually solves https://github.com/gulpjs/glob-watcher/issues/29 but it would make my code cleaner if it had an `immutable` method.  So I added it.  Thoughts?  Some other libraries put it in a sub-module like `object.defaults/immutable` so the require is nicer.  I'm open to either.